### PR TITLE
sketch-snippet-get-dom: Fix with-temp-buffer usage

### DIFF
--- a/sketch-mode.el
+++ b/sketch-mode.el
@@ -1789,10 +1789,10 @@ color."
 
 (defun sketch-snippet-get-dom (svg-file)
   (interactive "fCreate dom from file: ")
-  (with-temp-buffer "svg"
-                    (insert-file-contents-literally svg-file)
-                    (xml-remove-comments (point-min) (point-max))
-                    (libxml-parse-xml-region (point-min) (point-max))))
+  (with-temp-buffer
+    (insert-file-contents-literally svg-file)
+    (xml-remove-comments (point-min) (point-max))
+    (libxml-parse-xml-region (point-min) (point-max))))
 
 (defun sketch-snippets-add-ids (dom)
   (let ((idx 0))


### PR DESCRIPTION
This removes a no-op string presumably passed to `with-temp-buffer` as an unneeded buffer name.
Spotted by Mattias Engdegård in https://bugs.gnu.org/62620#8.